### PR TITLE
Change config to set apiScope differently for production and development environments

### DIFF
--- a/src/config/authConfig.ts
+++ b/src/config/authConfig.ts
@@ -32,13 +32,9 @@ export const loginRequest: RedirectRequest = {
   state: LOGIN_STATE,
 };
 
-let apiScope;
-
-if (apiClientId) {
-  apiScope = `api://${apiClientId}/.default`;
-} else {
-  apiScope = 'api://mad-learning/Read'
-}
+const apiScope = apiClientId
+  ? `api://${apiClientId}/.default`
+  : 'api://mad-learning/Read';
 
 export const API_TOKEN_STATE = 'api-token';
 

--- a/src/config/authConfig.ts
+++ b/src/config/authConfig.ts
@@ -32,7 +32,13 @@ export const loginRequest: RedirectRequest = {
   state: LOGIN_STATE,
 };
 
-const apiScope = `api://${apiClientId}/.default`;
+let apiScope;
+
+if (apiClientId) {
+  apiScope = `api://${apiClientId}/.default`;
+} else {
+  apiScope = 'api://mad-learning/Read'
+}
 
 export const API_TOKEN_STATE = 'api-token';
 


### PR DESCRIPTION
The apiScope has to be set differently to work in Production and Development.
It will now check if the apiClientId environment variable is set to apply
production apiScope.

To be able to run the project locally you have to create a file in scripts/ called:
generate-local-secrets-env.sh or generate-local-secrets-env.ps1 and they need to export
the environment variables MAD_LEARNING_WEB_CLIENT_ID and MAD_LEARNING_TENANT_ID