### PR TITLE
Feat/62 add teams link

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -61,7 +61,8 @@ export async function createEvent(
   imageUrl?: string,
   imageAlt?: string,
   location?: string,
-  eventType?: string
+  eventType?: string,
+  teamsUrl?: string,
 ): Promise<void> {
   const account = AuthProviderInstance.account;
   const accountName = AuthProviderInstance.accountName;
@@ -77,6 +78,7 @@ export async function createEvent(
       imageAlt: imageAlt,
       location: location,
       eventType: eventType,
+      teamsUrl: teamsUrl,
       owner: {
         // TODO: can be filled in API side unless you can create an event with an owner that is not current user
         id: account!.localAccountId,
@@ -112,7 +114,8 @@ export async function updateEvent(
   eventType: string,
   imageUrl?: string,
   imageAlt?: string,
-  location?: string
+  location?: string,
+  teamsUrl?: string
 ): Promise<void> {
   const response = await authFetch(`${API_URL}/api/event/${id}`, {
     method: 'PUT',
@@ -125,6 +128,7 @@ export async function updateEvent(
       imageAlt: imageAlt,
       location: location,
       eventType: eventType,
+      teamsUrl: teamsUrl,
     }),
   });
   if (response.ok) {

--- a/src/components/EventForm/EventForm.tsx
+++ b/src/components/EventForm/EventForm.tsx
@@ -77,7 +77,7 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
 
   const parseDate = (date: string, time: string) => new Date(date + 'T' + time);
 
-  const isFormValid = name && description && eventType && teamsUrl && startTime && endTime &&
+  const isFormValid = name && description && eventType && startTime && endTime &&
     parseDate(date, startTime) > now && parseDate(date, endTime) > now;
   const isSubmitDisabled = !isFormValid || isSubmitting;
 
@@ -173,7 +173,7 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
           name="teamsUrl"
           label="Teams URL"
           value={teamsUrl}
-          placeholder="teams.url"
+          placeholder="https://teams.microsoft.com/..."
           onChange={setTeamsUrl}
         />
         <TextField

--- a/src/components/EventForm/EventForm.tsx
+++ b/src/components/EventForm/EventForm.tsx
@@ -21,6 +21,7 @@ export type EventDataInput = {
   imageAlt?: string;
   location?: string;
   eventType?: string;
+  teamsUrl?: string;
 };
 
 export type EventDataOutput = {
@@ -33,6 +34,7 @@ export type EventDataOutput = {
   imageAlt?: string;
   location?: string;
   eventType: string;
+  teamsUrl?: string;
 };
 
 type EventFormProps = {
@@ -71,9 +73,11 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const [teamsUrl, setTeamsUrl] = useState(rest.teamsUrl || '');
+
   const parseDate = (date: string, time: string) => new Date(date + 'T' + time);
 
-  const isFormValid = name && description && eventType && startTime && endTime &&
+  const isFormValid = name && description && eventType && teamsUrl && startTime && endTime &&
     parseDate(date, startTime) > now && parseDate(date, endTime) > now;
   const isSubmitDisabled = !isFormValid || isSubmitting;
 
@@ -92,6 +96,7 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
         imageAlt,
         location,
         eventType,
+        teamsUrl,
       });
     } catch (error) {
       setError(error.message);
@@ -109,6 +114,7 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
     imageAlt,
     location,
     eventType,
+    teamsUrl,
     setIsSubmitting,
     setError,
     onSubmit,
@@ -160,8 +166,15 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
           name="location"
           label="Location"
           value={location}
-          placeholder="Teams"
+          placeholder="Jernlageret"
           onChange={setLocation}
+        />
+        <TextField
+          name="teamsUrl"
+          label="Teams URL"
+          value={teamsUrl}
+          placeholder="teams.url"
+          onChange={setTeamsUrl}
         />
         <TextField
           name="image"

--- a/src/config/authConfig.ts
+++ b/src/config/authConfig.ts
@@ -32,13 +32,9 @@ export const loginRequest: RedirectRequest = {
   state: LOGIN_STATE,
 };
 
-let apiScope;
-
-if (apiClientId) {
-  apiScope = `api://${apiClientId}/.default`;
-} else {
-  apiScope = 'api://mad-learning/Read'
-}
+const apiScope = apiClientId
+  ? `api://${apiClientId}/.default`
+  : 'api://mad-learning/Read';
 
 export const API_TOKEN_STATE = 'api-token';
 

--- a/src/config/authConfig.ts
+++ b/src/config/authConfig.ts
@@ -32,7 +32,13 @@ export const loginRequest: RedirectRequest = {
   state: LOGIN_STATE,
 };
 
-const apiScope = `api://${apiClientId}/.default`;
+let apiScope;
+
+if (apiClientId) {
+  apiScope = `api://${apiClientId}/.default`;
+} else {
+  apiScope = 'api://mad-learning/Read'
+}
 
 export const API_TOKEN_STATE = 'api-token';
 

--- a/src/fixtures/events.ts
+++ b/src/fixtures/events.ts
@@ -8,6 +8,7 @@ export const event: Event = {
   endTime: '2020-09-22T17:30:00+01',
   location: 'Jernlageret',
   eventType: 'Subject matter event',
+  teamsUrl: 'some.teams.url.com/test',
   imageUrl:
     'https://itera-cdn.azureedge.net/contentassets/df1f34b7803045fa95ffd4529826f2b2/kristian-redi-2.jpg?quality=60&Cache=Always&width=1148&mode=crop&scale=both',
   imageAlt: 'Bilde av folk som programmerer i fellesskap.',

--- a/src/pages/CreateEventPage/CreateEventPage.tsx
+++ b/src/pages/CreateEventPage/CreateEventPage.tsx
@@ -17,7 +17,8 @@ function CreateEvent({ navigate }: RouteComponentProps) {
       eventData.imageUrl,
       eventData.imageAlt,
       eventData.location,
-      eventData.eventType
+      eventData.eventType,
+      eventData.teamsUrl,
     );
     navigate!('/');
   };

--- a/src/pages/EventPage/EventPage.tsx
+++ b/src/pages/EventPage/EventPage.tsx
@@ -8,6 +8,7 @@ import RsvpButton from 'src/components/inputs/RsvpButton';
 import SplitSection from 'src/components/SplitSection';
 import MetaInfo from './components/MetaInfo';
 import ParticipantList from './components/ParticipantList';
+import TeamsLink from './components/TeamsLink';
 import { DescriptionText, HighlightedBox } from './styled';
 import { fetchEvent } from 'src/api/events';
 import DeleteButton from 'src/components/inputs/DeleteButton';
@@ -50,6 +51,7 @@ function EventPage({ eventId, navigate, ...rest }: EventPageProps) {
             location,
             owner,
             participants,
+            teamsUrl,
           } = event;
 
           const account = AuthProviderInstance.account;
@@ -91,6 +93,12 @@ function EventPage({ eventId, navigate, ...rest }: EventPageProps) {
                   <>
                     <h2>Description</h2>
                     <DescriptionText>{description}</DescriptionText>
+                    {teamsUrl && (
+                      <>
+                        <h2>Microsoft Teams Meeting:</h2>
+                        <TeamsLink teamsUrl={teamsUrl}></TeamsLink>
+                      </>
+                    )}
                   </>
                 }
                 right={

--- a/src/pages/EventPage/components/TeamsLink/TeamsLink.tsx
+++ b/src/pages/EventPage/components/TeamsLink/TeamsLink.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { Container } from './styled';
+
+type TeamsLinkProps = {
+  teamsUrl: string;
+};
+
+function TeamsLink({ teamsUrl }: TeamsLinkProps) {
+  return <Container>
+            <a href={teamsUrl}>Click here to join Teams meeting</a>
+          </Container>;
+}
+
+export default TeamsLink;

--- a/src/pages/EventPage/components/TeamsLink/index.ts
+++ b/src/pages/EventPage/components/TeamsLink/index.ts
@@ -1,0 +1,3 @@
+import TeamsLink from './TeamsLink';
+
+export default TeamsLink;

--- a/src/pages/EventPage/components/TeamsLink/styled.ts
+++ b/src/pages/EventPage/components/TeamsLink/styled.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+import { usingTypography } from 'src/hooks/theme';
+
+export const Container = styled.ul`
+  padding: 0;
+  list-style-type: none;
+  line-height: ${usingTypography((t) => t.scaleSpacing(9))}px;
+  text-decoration: underline;
+`;

--- a/src/pages/UpdateEventPage/UpdateEventPage.tsx
+++ b/src/pages/UpdateEventPage/UpdateEventPage.tsx
@@ -32,7 +32,8 @@ function UpdateEvent({
       eventData.eventType,
       eventData.imageUrl,
       eventData.imageAlt,
-      eventData.location
+      eventData.location,
+      eventData.teamsUrl,
     );
     navigate!(`/event/${eventId}/${eventData.name}`);
   };
@@ -66,6 +67,7 @@ function UpdateEvent({
               imageUrl={event.imageUrl}
               imageAlt={event.imageAlt}
               location={event.location}
+              teamsUrl={event.teamsUrl}
             />
           );
         }}

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -8,6 +8,7 @@ export type Event = {
   imageUrl: string;
   imageAlt: string;
   eventType: string;
+  teamsUrl: string;
   owner?: Person;
   participants?: Array<Person>;
 };


### PR DESCRIPTION
This commit aims to solve task #62 in the LevelUp board.
Added teams link as teamsUrl, which is not yet implemented in back-end.

The implementation in Create Event page looks like this:
![Skjermbilde 2021-09-06 140637](https://user-images.githubusercontent.com/33224882/132216316-93f2459f-2f1e-40db-af93-e86e56740f90.png)

The teams link is only displayed in the Event Page if it is fetched through the API.
If a teams url is provided it looks like this:
![Skjermbilde 2021-09-06 140727](https://user-images.githubusercontent.com/33224882/132216588-c5741269-6e95-442e-989f-ca3876561e90.png)

If a team url is not provided it looks like this:
![Skjermbilde 2021-09-06 140809](https://user-images.githubusercontent.com/33224882/132216649-98c50ea8-ab71-4e3b-9e1a-0aa159ed05b5.png)

