### PR TITLE
Add eventStatus to form, event page and event list

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -61,7 +61,8 @@ export async function createEvent(
   imageUrl?: string,
   imageAlt?: string,
   location?: string,
-  eventType?: string
+  eventType?: string,
+  eventStatus?: string
 ): Promise<void> {
   const account = AuthProviderInstance.account;
   const accountName = AuthProviderInstance.accountName;
@@ -77,6 +78,7 @@ export async function createEvent(
       imageAlt: imageAlt,
       location: location,
       eventType: eventType,
+      eventStatus: eventStatus,
       owner: {
         // TODO: can be filled in API side unless you can create an event with an owner that is not current user
         id: account!.localAccountId,
@@ -112,7 +114,8 @@ export async function updateEvent(
   eventType: string,
   imageUrl?: string,
   imageAlt?: string,
-  location?: string
+  location?: string,
+  eventStatus?: string
 ): Promise<void> {
   const response = await authFetch(`${API_URL}/api/event/${id}`, {
     method: 'PUT',
@@ -125,6 +128,7 @@ export async function updateEvent(
       imageAlt: imageAlt,
       location: location,
       eventType: eventType,
+      eventStatus: eventStatus,
     }),
   });
   if (response.ok) {

--- a/src/components/EventForm/EventForm.tsx
+++ b/src/components/EventForm/EventForm.tsx
@@ -9,7 +9,7 @@ import TextAreaField from 'src/components/fields/TextAreaField';
 import TextField from 'src/components/fields/TextField';
 import TimeField from 'src/components/fields/TimeField';
 import { EventFormWrapper, Form } from './styled';
-import { EVENT_OPTIONS } from './constants';
+import { EVENT_OPTIONS, EVENT_STATUS_OPTIONS } from './constants';
 
 export type EventDataInput = {
   id?: string;
@@ -21,6 +21,7 @@ export type EventDataInput = {
   imageAlt?: string;
   location?: string;
   eventType?: string;
+  eventStatus?: string;
 };
 
 export type EventDataOutput = {
@@ -33,6 +34,7 @@ export type EventDataOutput = {
   imageAlt?: string;
   location?: string;
   eventType: string;
+  eventStatus: string;
 };
 
 type EventFormProps = {
@@ -48,14 +50,10 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
   const [imageUrl, setImageUrl] = useState(rest.imageUrl || '');
   const [imageAlt, setImageAlt] = useState(rest.imageAlt || '');
   const eventDate = rest.startTime || addDays(startOfDay(now), 1);
-  const [date, setDate] = useState(
-    format(
-      eventDate,
-      'yyyy-MM-dd'
-    )
-  );
+  const [date, setDate] = useState(format(eventDate, 'yyyy-MM-dd'));
 
-  const setHours = (date: Date, hours: number) => set(date, { hours: hours, minutes: 0, seconds: 0, milliseconds: 0 })
+  const setHours = (date: Date, hours: number) =>
+    set(date, { hours: hours, minutes: 0, seconds: 0, milliseconds: 0 });
 
   const [startTime, setStartTime] = useState(
     format(rest.startTime || setHours(eventDate, 16), 'HH:mm')
@@ -65,6 +63,9 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
   );
   const [description, setDescription] = useState(rest.description || '');
   const [eventType, setEventType] = useState(rest.eventType || '');
+  const [eventStatus, setEventStatus] = useState(
+    rest.eventStatus || EVENT_STATUS_OPTIONS[0]
+  );
   const [location, setLocation] = useState(rest.location || '');
 
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -73,8 +74,14 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
 
   const parseDate = (date: string, time: string) => new Date(date + 'T' + time);
 
-  const isFormValid = name && description && eventType && startTime && endTime &&
-    parseDate(date, startTime) > now && parseDate(date, endTime) > now;
+  const isFormValid =
+    name &&
+    description &&
+    eventType &&
+    startTime &&
+    endTime &&
+    parseDate(date, startTime) > now &&
+    parseDate(date, endTime) > now;
   const isSubmitDisabled = !isFormValid || isSubmitting;
 
   const handleSubmit = useCallback(async () => {
@@ -92,6 +99,7 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
         imageAlt,
         location,
         eventType,
+        eventStatus,
       });
     } catch (error) {
       setError(error.message);
@@ -109,6 +117,7 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
     imageAlt,
     location,
     eventType,
+    eventStatus,
     setIsSubmitting,
     setError,
     onSubmit,
@@ -132,12 +141,7 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
           onChange={setEventType}
           options={EVENT_OPTIONS}
         />
-        <DateField
-          name="date"
-          label="Date *"
-          value={date}
-          onChange={setDate}
-        />
+        <DateField name="date" label="Date *" value={date} onChange={setDate} />
         <TimeField
           name="time"
           label="Start time *"
@@ -175,6 +179,13 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
           label="Image text"
           value={imageAlt}
           onChange={setImageAlt}
+        />
+        <SelectField
+          name="eventStatus"
+          label="Event status *"
+          value={eventStatus}
+          onChange={setEventStatus}
+          options={EVENT_STATUS_OPTIONS}
         />
         <div>
           <Button disabled={isSubmitDisabled} onClick={handleSubmit}>

--- a/src/components/EventForm/EventForm.tsx
+++ b/src/components/EventForm/EventForm.tsx
@@ -66,7 +66,7 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
   const [description, setDescription] = useState(rest.description || '');
   const [eventType, setEventType] = useState(rest.eventType || '');
   const [eventStatus, setEventStatus] = useState(
-    rest.eventStatus || EVENT_STATUS_OPTIONS[0]
+    rest.eventStatus || EVENT_STATUS_OPTIONS.Draft
   );
   const [location, setLocation] = useState(rest.location || '');
 
@@ -198,7 +198,7 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
           label="Event status *"
           value={eventStatus}
           onChange={setEventStatus}
-          options={EVENT_STATUS_OPTIONS}
+          options={Object.keys(EVENT_STATUS_OPTIONS)}
         />
         <div>
           <Button disabled={isSubmitDisabled} onClick={handleSubmit}>

--- a/src/components/EventForm/EventForm.tsx
+++ b/src/components/EventForm/EventForm.tsx
@@ -9,7 +9,8 @@ import TextAreaField from 'src/components/fields/TextAreaField';
 import TextField from 'src/components/fields/TextField';
 import TimeField from 'src/components/fields/TimeField';
 import { EventFormWrapper, Form } from './styled';
-import { EVENT_OPTIONS, EVENT_STATUS_OPTIONS } from './constants';
+import { EVENT_OPTIONS } from './constants';
+import { EVENT_STATUS_OPTIONS } from 'src/utils/constants'
 
 export type EventDataInput = {
   id?: string;

--- a/src/components/EventForm/constants.ts
+++ b/src/components/EventForm/constants.ts
@@ -5,3 +5,5 @@ export const EVENT_OPTIONS: string[] = [
   'Project presentation',
   'Workshop',
 ];
+
+export const EVENT_STATUS_OPTIONS: string[] = ['Draft', 'Published'];

--- a/src/components/EventForm/constants.ts
+++ b/src/components/EventForm/constants.ts
@@ -5,8 +5,3 @@ export const EVENT_OPTIONS: string[] = [
   'Project presentation',
   'Workshop',
 ];
-
-export enum EVENT_STATUS_OPTIONS {
-  Draft = 'Draft',
-  Published = 'Published',
-}

--- a/src/components/EventForm/constants.ts
+++ b/src/components/EventForm/constants.ts
@@ -6,4 +6,7 @@ export const EVENT_OPTIONS: string[] = [
   'Workshop',
 ];
 
-export const EVENT_STATUS_OPTIONS: string[] = ['Draft', 'Published'];
+export enum EVENT_STATUS_OPTIONS {
+  Draft = 'Draft',
+  Published = 'Published',
+}

--- a/src/fixtures/events.ts
+++ b/src/fixtures/events.ts
@@ -8,6 +8,7 @@ export const event: Event = {
   endTime: '2020-09-22T17:30:00+01',
   location: 'Jernlageret',
   eventType: 'Subject matter event',
+  eventStatus: 'Published',
   imageUrl:
     'https://itera-cdn.azureedge.net/contentassets/df1f34b7803045fa95ffd4529826f2b2/kristian-redi-2.jpg?quality=60&Cache=Always&width=1148&mode=crop&scale=both',
   imageAlt: 'Bilde av folk som programmerer i fellesskap.',

--- a/src/fixtures/events.ts
+++ b/src/fixtures/events.ts
@@ -1,4 +1,5 @@
 import { Event } from 'src/types/domain';
+import { EVENT_STATUS_OPTIONS } from 'src/utils/constants';
 
 export const event: Event = {
   id: '0',
@@ -8,7 +9,7 @@ export const event: Event = {
   endTime: '2020-09-22T17:30:00+01',
   location: 'Jernlageret',
   eventType: 'Subject matter event',
-  eventStatus: 'Published',
+  eventStatus: EVENT_STATUS_OPTIONS.Published,
   teamsUrl: 'https://teams.microsoft.com',
   imageUrl:
     'https://itera-cdn.azureedge.net/contentassets/df1f34b7803045fa95ffd4529826f2b2/kristian-redi-2.jpg?quality=60&Cache=Always&width=1148&mode=crop&scale=both',

--- a/src/pages/CreateEventPage/CreateEventPage.tsx
+++ b/src/pages/CreateEventPage/CreateEventPage.tsx
@@ -17,14 +17,19 @@ function CreateEvent({ navigate }: RouteComponentProps) {
       eventData.imageUrl,
       eventData.imageAlt,
       eventData.location,
-      eventData.eventType
+      eventData.eventType,
+      eventData.eventStatus
     );
     navigate!('/');
   };
 
   return (
     <CreateEventWrapper>
-      <EventForm onSubmit={handleSubmit} headerTitle={'Create new event'} submitTitle={'Create'} />
+      <EventForm
+        onSubmit={handleSubmit}
+        headerTitle={'Create new event'}
+        submitTitle={'Create'}
+      />
     </CreateEventWrapper>
   );
 }

--- a/src/pages/EventPage/EventPage.tsx
+++ b/src/pages/EventPage/EventPage.tsx
@@ -8,6 +8,7 @@ import RsvpButton from 'src/components/inputs/RsvpButton';
 import SplitSection from 'src/components/SplitSection';
 import MetaInfo from './components/MetaInfo';
 import ParticipantList from './components/ParticipantList';
+import StatusLabel from './components/StatusLabel';
 import { DescriptionText, HighlightedBox } from './styled';
 import { fetchEvent } from 'src/api/events';
 import DeleteButton from 'src/components/inputs/DeleteButton';
@@ -50,6 +51,7 @@ function EventPage({ eventId, navigate, ...rest }: EventPageProps) {
             location,
             owner,
             participants,
+            eventStatus,
           } = event;
 
           const account = AuthProviderInstance.account;
@@ -61,6 +63,7 @@ function EventPage({ eventId, navigate, ...rest }: EventPageProps) {
             <>
               <header>
                 <h1>{name}</h1>
+                {!isNotOwner && <StatusLabel eventStatus={eventStatus} />}
                 <HighlightedBox>
                   <MetaInfo
                     name={name}

--- a/src/pages/EventPage/components/StatusLabel/StatusLabel.tsx
+++ b/src/pages/EventPage/components/StatusLabel/StatusLabel.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Container, Label, HelpText } from './styled';
+
+type StatusLabelProps = {
+  eventStatus: string;
+};
+
+function StatusLabel({ eventStatus }: StatusLabelProps) {
+  if (eventStatus === 'Draft')
+    return (
+      <Container>
+        <Label color="grey">Draft</Label>
+        <HelpText>This event is only visible to you</HelpText>
+      </Container>
+    );
+  else {
+    return (
+      <Container>
+        <Label color="green">Published</Label>
+      </Container>
+    );
+  }
+}
+
+export default StatusLabel;

--- a/src/pages/EventPage/components/StatusLabel/StatusLabel.tsx
+++ b/src/pages/EventPage/components/StatusLabel/StatusLabel.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Container, Label, HelpText } from './styled';
+import { EVENT_STATUS_OPTIONS } from 'src/utils/constants'
 
 type StatusLabelProps = {
   eventStatus: string;
 };
 
 function StatusLabel({ eventStatus }: StatusLabelProps) {
-  if (eventStatus === 'Draft')
+  if (eventStatus === EVENT_STATUS_OPTIONS.Draft)
     return (
       <Container>
         <Label color="grey">Draft</Label>

--- a/src/pages/EventPage/components/StatusLabel/index.ts
+++ b/src/pages/EventPage/components/StatusLabel/index.ts
@@ -1,0 +1,3 @@
+import StatusLabel from './StatusLabel';
+
+export default StatusLabel;

--- a/src/pages/EventPage/components/StatusLabel/styled.ts
+++ b/src/pages/EventPage/components/StatusLabel/styled.ts
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+export const Container = styled.ul`
+  padding: 0;
+  margin-bottom: 10px;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+`;
+
+export const Label = styled.ul`
+  margin-top: 0;
+  margin-right: 10px;
+  padding: 10px;
+  display: inline-block;
+  color: white;
+  background-color: ${(props) => props.color};
+  border-radius: 5px;
+`;
+
+export const HelpText = styled.ul`
+  color: grey;
+  text-decoration: underline;
+`;

--- a/src/pages/LandingPage/components/EventList/EventList.tsx
+++ b/src/pages/LandingPage/components/EventList/EventList.tsx
@@ -30,13 +30,14 @@ function EventList({ events }: EventListProps) {
 
   return (
     <GridList>
-      {events.map(({ id, name, startTime, location, imageUrl, imageAlt }) => (
+      {events.map(({ id, name, startTime, location, imageUrl, imageAlt, eventStatus }) => (
         <GridItem key={id}>
           <Link to={`/event/${id}/${name}`}>
             <EventCard
               heading={name}
               image={imageUrl}
               imageAlt={imageAlt}
+              eventStatus={eventStatus}
               content={
                 <EventInfoList>
                   <EventInfo>

--- a/src/pages/LandingPage/components/EventList/components/EventCard/EventCard.tsx
+++ b/src/pages/LandingPage/components/EventList/components/EventCard/EventCard.tsx
@@ -1,5 +1,7 @@
 import React, { ReactNode, useState } from 'react';
 
+import CardStatusLabel from './components/CardStatusLabel';
+
 import {
   Container,
   Image,
@@ -14,18 +16,27 @@ type EventCardProps = {
   image: string;
   imageAlt: string;
   content: ReactNode;
+  eventStatus: string;
 };
 
 const FALLBACK_IMAGE =
   'https://itera-cdn.azureedge.net/globalassets/6.-newsroom/aktuelt.png?quality=60&Cache=Always&width=1148&mode=crop&scale=both';
 
-function EventCard({ heading, content, image, imageAlt }: EventCardProps) {
+function EventCard({
+  heading,
+  content,
+  image,
+  imageAlt,
+  eventStatus,
+}: EventCardProps) {
   const [hasBrokenImage, setHasBrokenImage] = useState(false);
 
   const img = hasBrokenImage ? FALLBACK_IMAGE : image;
 
   return (
     <Container>
+      <CardStatusLabel eventStatus={eventStatus}></CardStatusLabel>
+
       <ImageContainer>
         <Image
           src={img}

--- a/src/pages/LandingPage/components/EventList/components/EventCard/components/CardStatusLabel/CardStatusLabel.tsx
+++ b/src/pages/LandingPage/components/EventList/components/EventCard/components/CardStatusLabel/CardStatusLabel.tsx
@@ -9,7 +9,7 @@ function CardStatusLabel({ eventStatus }: StatusLabelProps) {
   if (eventStatus === 'Draft')
     return (
       <Container>
-        <Label color="black">
+        <Label>
           Draft<HelpText>This event is only visible to you</HelpText>
         </Label>
       </Container>

--- a/src/pages/LandingPage/components/EventList/components/EventCard/components/CardStatusLabel/CardStatusLabel.tsx
+++ b/src/pages/LandingPage/components/EventList/components/EventCard/components/CardStatusLabel/CardStatusLabel.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Container, Label, HelpText } from './styled';
+
+type StatusLabelProps = {
+  eventStatus: string;
+};
+
+function CardStatusLabel({ eventStatus }: StatusLabelProps) {
+  if (eventStatus === 'Draft')
+    return (
+      <Container>
+        <Label color="black">
+          Draft<HelpText>This event is only visible to you</HelpText>
+        </Label>
+      </Container>
+    );
+  else {
+    return null;
+  }
+}
+
+export default CardStatusLabel;

--- a/src/pages/LandingPage/components/EventList/components/EventCard/components/CardStatusLabel/CardStatusLabel.tsx
+++ b/src/pages/LandingPage/components/EventList/components/EventCard/components/CardStatusLabel/CardStatusLabel.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Container, Label, HelpText } from './styled';
+import { EVENT_STATUS_OPTIONS } from 'src/utils/constants'
 
 type StatusLabelProps = {
   eventStatus: string;
 };
 
 function CardStatusLabel({ eventStatus }: StatusLabelProps) {
-  if (eventStatus === 'Draft')
+  if (eventStatus === EVENT_STATUS_OPTIONS.Draft)
     return (
       <Container>
         <Label>

--- a/src/pages/LandingPage/components/EventList/components/EventCard/components/CardStatusLabel/index.ts
+++ b/src/pages/LandingPage/components/EventList/components/EventCard/components/CardStatusLabel/index.ts
@@ -1,0 +1,3 @@
+import CardStatusLabel from './CardStatusLabel';
+
+export default CardStatusLabel;

--- a/src/pages/LandingPage/components/EventList/components/EventCard/components/CardStatusLabel/styled.ts
+++ b/src/pages/LandingPage/components/EventList/components/EventCard/components/CardStatusLabel/styled.ts
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+import { usingTypography } from 'src/hooks/theme';
+
+export const Container = styled.ul`
+  display: flex;
+  justify-content: flex-start;
+  position: relative;
+  color: white;
+`;
+
+export const Label = styled.ul`
+  top: 0;
+  left: 0;
+  position: absolute;
+  //margin: 0;
+  padding: 20px;
+  background-color: rgba(0, 0, 0, 0.4);
+  font-size: ${usingTypography((t) => t.scaleFont(5))}px;
+`;
+
+export const HelpText = styled.ul`
+  padding-left: 0;
+  font-size: ${usingTypography((t) => t.scaleFont(-3))}px;
+`;

--- a/src/pages/UpdateEventPage/UpdateEventPage.tsx
+++ b/src/pages/UpdateEventPage/UpdateEventPage.tsx
@@ -32,7 +32,8 @@ function UpdateEvent({
       eventData.eventType,
       eventData.imageUrl,
       eventData.imageAlt,
-      eventData.location
+      eventData.location,
+      eventData.eventStatus
     );
     navigate!(`/event/${eventId}/${eventData.name}`);
   };
@@ -66,6 +67,7 @@ function UpdateEvent({
               imageUrl={event.imageUrl}
               imageAlt={event.imageAlt}
               location={event.location}
+              eventStatus={event.eventStatus}
             />
           );
         }}

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -8,6 +8,7 @@ export type Event = {
   imageUrl: string;
   imageAlt: string;
   eventType: string;
+  eventStatus: string;
   owner?: Person;
   participants?: Array<Person>;
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,4 @@
+export enum EVENT_STATUS_OPTIONS {
+  Draft = 'Draft',
+  Published = 'Published',
+}


### PR DESCRIPTION
Add SelectField in create event form to set eventStatus to either "Draft" or
"Published". eventStatus can be changed in the update event form aswell.
Events on the front page will be labelled if the eventStatus is set to
"Draft". When viewing a single event that belongs to you, the event will
be marked with a label at the top with either "Draft" or "Published".