### PR TITLE
Feat/72 publish button

### DIFF
--- a/src/components/EventForm/EventForm.tsx
+++ b/src/components/EventForm/EventForm.tsx
@@ -10,7 +10,7 @@ import TextField from 'src/components/fields/TextField';
 import TimeField from 'src/components/fields/TimeField';
 import { EventFormWrapper, Form } from './styled';
 import { EVENT_OPTIONS } from './constants';
-import { EventStatus } from 'src/utils/constants'
+import { EventStatus } from 'src/utils/constants';
 
 export type EventDataInput = {
   id?: string;
@@ -66,9 +66,7 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
   );
   const [description, setDescription] = useState(rest.description || '');
   const [eventType, setEventType] = useState(rest.eventType || '');
-  const [eventStatus, setEventStatus] = useState(
-    rest.eventStatus || EventStatus.DRAFT
-  );
+
   const [location, setLocation] = useState(rest.location || '');
 
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -77,6 +75,7 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
 
   const [teamsUrl, setTeamsUrl] = useState(rest.teamsUrl || '');
 
+  const eventStatus = rest.eventStatus || EventStatus.DRAFT;
   const parseDate = (date: string, time: string) => new Date(date + 'T' + time);
 
   const isFormValid =
@@ -193,13 +192,6 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
           label="Image text"
           value={imageAlt}
           onChange={setImageAlt}
-        />
-        <SelectField
-          name="eventStatus"
-          label="Event status *"
-          value={eventStatus}
-          onChange={setEventStatus}
-          options={Object.values(EventStatus)}
         />
         <div>
           <Button disabled={isSubmitDisabled} onClick={handleSubmit}>

--- a/src/components/EventForm/EventForm.tsx
+++ b/src/components/EventForm/EventForm.tsx
@@ -10,7 +10,7 @@ import TextField from 'src/components/fields/TextField';
 import TimeField from 'src/components/fields/TimeField';
 import { EventFormWrapper, Form } from './styled';
 import { EVENT_OPTIONS } from './constants';
-import { EVENT_STATUS_OPTIONS } from 'src/utils/constants'
+import { EventStatus } from 'src/utils/constants'
 
 export type EventDataInput = {
   id?: string;
@@ -67,7 +67,7 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
   const [description, setDescription] = useState(rest.description || '');
   const [eventType, setEventType] = useState(rest.eventType || '');
   const [eventStatus, setEventStatus] = useState(
-    rest.eventStatus || EVENT_STATUS_OPTIONS.Draft
+    rest.eventStatus || EventStatus.DRAFT
   );
   const [location, setLocation] = useState(rest.location || '');
 
@@ -199,7 +199,7 @@ function EventForm({ onSubmit, ...rest }: EventFormProps) {
           label="Event status *"
           value={eventStatus}
           onChange={setEventStatus}
-          options={Object.keys(EVENT_STATUS_OPTIONS)}
+          options={Object.values(EventStatus)}
         />
         <div>
           <Button disabled={isSubmitDisabled} onClick={handleSubmit}>

--- a/src/components/Modal/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/Modal/ConfirmationModal/ConfirmationModal.tsx
@@ -3,12 +3,16 @@ import Button from 'src/components/inputs/Button';
 import { ConfirmationButtons, Message } from './styled';
 
 type ConfirmationModalProps = {
+  confirmText: string;
+  cancelText: string;
   onConfirm: () => void;
   onCancel: () => void;
   message: string;
 };
 
 function ConfirmationModal({
+  confirmText,
+  cancelText,
   onConfirm,
   onCancel,
   message,
@@ -17,8 +21,8 @@ function ConfirmationModal({
     <>
       <Message>{message}</Message>
       <ConfirmationButtons>
-        <Button onClick={onConfirm}>Confirm</Button>
-        <Button onClick={onCancel}>Cancel</Button>
+        <Button onClick={onConfirm}>{confirmText}</Button>
+        <Button onClick={onCancel}>{cancelText}</Button>
       </ConfirmationButtons>
     </>
   );

--- a/src/components/Modal/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/Modal/ConfirmationModal/ConfirmationModal.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Button from 'src/components/inputs/Button';
+import { ConfirmationButtons, Message } from './styled';
+
+type ConfirmationModalProps = {
+  onConfirm: () => void;
+  onCancel: () => void;
+  message: string;
+};
+
+function ConfirmationModal({
+  onConfirm,
+  onCancel,
+  message,
+}: ConfirmationModalProps) {
+  return (
+    <>
+      <Message>{message}</Message>
+      <ConfirmationButtons>
+        <Button onClick={onConfirm}>Confirm</Button>
+        <Button onClick={onCancel}>Cancel</Button>
+      </ConfirmationButtons>
+    </>
+  );
+}
+
+export default ConfirmationModal;

--- a/src/components/Modal/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/Modal/ConfirmationModal/ConfirmationModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Button from 'src/components/inputs/Button';
-import { ConfirmationButtons, Message } from './styled';
+import { Controls, Message } from './styled';
 
 type ConfirmationModalProps = {
   confirmText: string;
@@ -20,10 +20,10 @@ function ConfirmationModal({
   return (
     <>
       <Message>{message}</Message>
-      <ConfirmationButtons>
+      <Controls>
         <Button onClick={onConfirm}>{confirmText}</Button>
         <Button onClick={onCancel}>{cancelText}</Button>
-      </ConfirmationButtons>
+      </Controls>
     </>
   );
 }

--- a/src/components/Modal/ConfirmationModal/index.ts
+++ b/src/components/Modal/ConfirmationModal/index.ts
@@ -1,0 +1,3 @@
+import ConfirmationModal from './ConfirmationModal';
+
+export default ConfirmationModal;

--- a/src/components/Modal/ConfirmationModal/styled.ts
+++ b/src/components/Modal/ConfirmationModal/styled.ts
@@ -4,6 +4,7 @@ import { usingTypography } from 'src/hooks/theme';
 export const ConfirmationButtons = styled.div`
   display: flex;
   justify-content: center;
+  gap: 1rem;
 `;
 export const Message = styled.div`
   font-size: ${usingTypography((t) => t.scaleFont(1))}px;

--- a/src/components/Modal/ConfirmationModal/styled.ts
+++ b/src/components/Modal/ConfirmationModal/styled.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+import { usingTypography } from 'src/hooks/theme';
+
+export const ConfirmationButtons = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+export const Message = styled.div`
+  font-size: ${usingTypography((t) => t.scaleFont(1))}px;
+  margin-bottom: 10px;
+  text-align: center;
+`;

--- a/src/components/Modal/ConfirmationModal/styled.ts
+++ b/src/components/Modal/ConfirmationModal/styled.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { usingTypography } from 'src/hooks/theme';
 
-export const ConfirmationButtons = styled.div`
+export const Controls = styled.div`
   display: flex;
   justify-content: center;
   gap: 1rem;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {
+  Wrapper,
+  Header,
+  StyledModal,
+  HeaderText,
+  CloseButton,
+  Content,
+  Backdrop,
+} from './styled';
+
+type ModalProps = {
+  isShown: boolean;
+  hide: () => void;
+  modalContent: JSX.Element;
+  headerText: string;
+};
+
+function Modal({ isShown, hide, modalContent, headerText }: ModalProps) {
+  const modal = (
+    <>
+      <Backdrop />
+      <Wrapper>
+        <StyledModal>
+          <Header>
+            <HeaderText>{headerText}</HeaderText>
+            <CloseButton onClick={hide}>X</CloseButton>
+          </Header>
+          <Content>{modalContent}</Content>
+        </StyledModal>
+      </Wrapper>
+    </>
+  );
+  return isShown ? ReactDOM.createPortal(modal, document.body) : null;
+}
+
+export default Modal;

--- a/src/components/Modal/index.ts
+++ b/src/components/Modal/index.ts
@@ -1,0 +1,3 @@
+import Modal from './Modal';
+
+export default Modal;

--- a/src/components/Modal/styled.ts
+++ b/src/components/Modal/styled.ts
@@ -20,7 +20,6 @@ export const Backdrop = styled.div`
   z-index: 500;
 `;
 export const StyledModal = styled.div`
-  z-index: 100;
   background: white;
   position: relative;
   margin: auto;
@@ -44,7 +43,7 @@ export const CloseButton = styled.button`
   border-radius: 3px;
   margin-left: 0.5rem;
   background: none;
-  :hover {
+  &:hover {
     cursor: pointer;
   }
 `;

--- a/src/components/Modal/styled.ts
+++ b/src/components/Modal/styled.ts
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+import { usingColors, usingTypography } from 'src/hooks/theme';
+
+export const Wrapper = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 700;
+  width: inherit;
+  outline: 0;
+`;
+export const Backdrop = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 500;
+`;
+export const StyledModal = styled.div`
+  z-index: 100;
+  background: white;
+  position: relative;
+  margin: auto;
+  max-width: 30rem;
+`;
+export const Header = styled.div`
+  background-color: ${usingColors((c) => c.SURFACE.SECONDARY)};
+  display: flex;
+  justify-content: space-between;
+  padding: 0.3rem;
+`;
+export const HeaderText = styled.div`
+  color: ${usingColors((c) => c.ON.SECONDARY)};
+  align-self: center;
+  color: lightgray;
+`;
+export const CloseButton = styled.button`
+  font-size: ${usingTypography((t) => t.scaleFont(1))}px;
+  color: white;
+  border: none;
+  border-radius: 3px;
+  margin-left: 0.5rem;
+  background: none;
+  :hover {
+    cursor: pointer;
+  }
+`;
+export const Content = styled.div`
+  padding: 10px;
+  max-height: 30rem;
+  overflow-x: hidden;
+  overflow-y: auto;
+`;

--- a/src/components/inputs/DeleteButton/DeleteButton.tsx
+++ b/src/components/inputs/DeleteButton/DeleteButton.tsx
@@ -46,6 +46,8 @@ function DeleteButton({ event, onDelete }: DeleteButtonProps) {
         headerText="Confirmation"
         modalContent={
           <ConfirmationModal
+            confirmText="DELETE"
+            cancelText="CANCEL"
             onConfirm={onConfirm}
             onCancel={onCancel}
             message="Are you sure you want to delete this event?"

--- a/src/components/inputs/DeleteButton/DeleteButton.tsx
+++ b/src/components/inputs/DeleteButton/DeleteButton.tsx
@@ -4,6 +4,9 @@ import Button from 'src/components/inputs/Button';
 import { Event } from 'src/types/domain';
 import { deleteEvent } from 'src/api/events';
 import { AuthProviderInstance } from 'src/utils/auth';
+import Modal from 'src/components/Modal';
+import ConfirmationModal from 'src/components/Modal/ConfirmationModal';
+import { useModal } from 'src/hooks/useModal';
 
 type DeleteButtonProps = {
   event: Event;
@@ -15,6 +18,14 @@ function DeleteButton({ event, onDelete }: DeleteButtonProps) {
 
   const isNotOwner = account && event.owner?.id !== account.localAccountId;
 
+  const { isShown, toggle } = useModal();
+
+  const onConfirm = () => {
+    handleDelete();
+    toggle();
+  };
+  const onCancel = () => toggle();
+
   const handleDelete = useCallback(async () => {
     await deleteEvent(event.id);
     onDelete();
@@ -25,13 +36,23 @@ function DeleteButton({ event, onDelete }: DeleteButtonProps) {
   }
 
   return (
-    <Button
-      variant="highlight"
-      onClick={handleDelete}
-      disabled={account == null}
-    >
-      Delete
-    </Button>
+    <>
+      <Button variant="highlight" onClick={toggle} disabled={account == null}>
+        Delete
+      </Button>
+      <Modal
+        isShown={isShown}
+        hide={toggle}
+        headerText="Confirmation"
+        modalContent={
+          <ConfirmationModal
+            onConfirm={onConfirm}
+            onCancel={onCancel}
+            message="Are you sure you want to delete this event?"
+          />
+        }
+      />
+    </>
   );
 }
 

--- a/src/components/inputs/DeleteButton/DeleteButton.tsx
+++ b/src/components/inputs/DeleteButton/DeleteButton.tsx
@@ -24,7 +24,7 @@ function DeleteButton({ event, onDelete }: DeleteButtonProps) {
     handleDelete();
     toggle();
   };
-  const onCancel = () => toggle();
+  const onCancel = toggle;
 
   const handleDelete = useCallback(async () => {
     await deleteEvent(event.id);

--- a/src/components/inputs/PublishButton/PublishButton.tsx
+++ b/src/components/inputs/PublishButton/PublishButton.tsx
@@ -49,6 +49,8 @@ function PublishButton({ event, onPublish }: PublishButtonProps) {
         headerText="Confirmation"
         modalContent={
           <ConfirmationModal
+            confirmText="PUBLISH"
+            cancelText="CANCEL"
             onConfirm={onConfirm}
             onCancel={onCancel}
             message="Are you sure you want to publish this event? This action is not reversible and a slack message will be posted in #fagkvelder-norge"

--- a/src/components/inputs/PublishButton/PublishButton.tsx
+++ b/src/components/inputs/PublishButton/PublishButton.tsx
@@ -3,6 +3,9 @@ import { Event } from 'src/types/domain';
 import { updateEvent } from 'src/api/events';
 import { EventStatus } from 'src/utils/constants';
 import Button from 'src/components/inputs/Button';
+import Modal from 'src/components/Modal';
+import ConfirmationModal from 'src/components/Modal/ConfirmationModal';
+import { useModal } from 'src/hooks/useModal';
 
 type PublishButtonProps = {
   event: Event;
@@ -10,8 +13,15 @@ type PublishButtonProps = {
 };
 
 function PublishButton({ event, onPublish }: PublishButtonProps) {
+  const { isShown, toggle } = useModal();
+
+  const onConfirm = () => {
+    handlePublish(event);
+    toggle();
+  };
+  const onCancel = () => toggle();
+
   const handlePublish = async (event: Event) => {
-    console.log(event);
     await updateEvent(
       event.id,
       event.startTime,
@@ -29,9 +39,23 @@ function PublishButton({ event, onPublish }: PublishButtonProps) {
   };
 
   return (
-    <Button variant="highlight" onClick={() => handlePublish(event)}>
-      Publish
-    </Button>
+    <>
+      <Button variant="highlight" onClick={toggle}>
+        Publish
+      </Button>
+      <Modal
+        isShown={isShown}
+        hide={toggle}
+        headerText="Confirmation"
+        modalContent={
+          <ConfirmationModal
+            onConfirm={onConfirm}
+            onCancel={onCancel}
+            message="Are you sure you want to publish this event? This action is not reversible and a slack message will be posted in #fagkvelder-norge"
+          />
+        }
+      />
+    </>
   );
 }
 

--- a/src/components/inputs/PublishButton/PublishButton.tsx
+++ b/src/components/inputs/PublishButton/PublishButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Event } from 'src/types/domain';
+import { updateEvent } from 'src/api/events';
+import { EventStatus } from 'src/utils/constants';
+import Button from 'src/components/inputs/Button';
+
+type PublishButtonProps = {
+  event: Event;
+  onPublish: (path: string) => void;
+};
+
+function PublishButton({ event, onPublish }: PublishButtonProps) {
+  const handlePublish = async (event: Event) => {
+    console.log(event);
+    await updateEvent(
+      event.id,
+      event.startTime,
+      event.endTime,
+      event.name,
+      event.description,
+      event.eventType,
+      event.imageUrl,
+      event.imageAlt,
+      event.location,
+      EventStatus.PUBLISHED,
+      event.teamsUrl
+    );
+    onPublish(`/event/${event.id}/${event.name}`);
+  };
+
+  return (
+    <Button variant="highlight" onClick={() => handlePublish(event)}>
+      Publish
+    </Button>
+  );
+}
+
+export default PublishButton;

--- a/src/components/inputs/PublishButton/PublishButton.tsx
+++ b/src/components/inputs/PublishButton/PublishButton.tsx
@@ -53,7 +53,7 @@ function PublishButton({ event, onPublish }: PublishButtonProps) {
             cancelText="CANCEL"
             onConfirm={onConfirm}
             onCancel={onCancel}
-            message="Are you sure you want to publish this event? This action is not reversible and a slack message will be posted in #fagkvelder-norge"
+            message="Are you sure you want to publish this event? This action is not reversible."
           />
         }
       />

--- a/src/components/inputs/PublishButton/index.ts
+++ b/src/components/inputs/PublishButton/index.ts
@@ -1,0 +1,3 @@
+import PublishButton from './PublishButton';
+
+export default PublishButton;

--- a/src/fixtures/events.ts
+++ b/src/fixtures/events.ts
@@ -1,5 +1,5 @@
 import { Event } from 'src/types/domain';
-import { EVENT_STATUS_OPTIONS } from 'src/utils/constants';
+import { EventStatus } from 'src/utils/constants';
 
 export const event: Event = {
   id: '0',
@@ -9,7 +9,7 @@ export const event: Event = {
   endTime: '2020-09-22T17:30:00+01',
   location: 'Jernlageret',
   eventType: 'Subject matter event',
-  eventStatus: EVENT_STATUS_OPTIONS.Published,
+  eventStatus: EventStatus.PUBLISHED,
   teamsUrl: 'https://teams.microsoft.com',
   imageUrl:
     'https://itera-cdn.azureedge.net/contentassets/df1f34b7803045fa95ffd4529826f2b2/kristian-redi-2.jpg?quality=60&Cache=Always&width=1148&mode=crop&scale=both',

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,0 +1,10 @@
+import { useState } from 'react';
+
+export const useModal = () => {
+  const [isShown, setIsShown] = useState<boolean>(false);
+  const toggle = () => setIsShown(!isShown);
+  return {
+    isShown,
+    toggle,
+  };
+};

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 export const useModal = () => {
-  const [isShown, setIsShown] = useState<boolean>(false);
+  const [isShown, setIsShown] = useState(false);
   const toggle = () => setIsShown(!isShown);
   return {
     isShown,

--- a/src/pages/CreateEventPage/CreateEventPage.tsx
+++ b/src/pages/CreateEventPage/CreateEventPage.tsx
@@ -28,8 +28,8 @@ function CreateEvent({ navigate }: RouteComponentProps) {
     <CreateEventWrapper>
       <EventForm
         onSubmit={handleSubmit}
-        headerTitle={'Create new event'}
-        submitTitle={'Create'}
+        headerTitle="Create new event"
+        submitTitle="Create"
       />
     </CreateEventWrapper>
   );

--- a/src/pages/EventPage/EventPage.tsx
+++ b/src/pages/EventPage/EventPage.tsx
@@ -10,7 +10,7 @@ import MetaInfo from './components/MetaInfo';
 import ParticipantList from './components/ParticipantList';
 import StatusLabel from './components/StatusLabel';
 import TeamsLink from './components/TeamsLink';
-import { DescriptionText, HighlightedBox } from './styled';
+import { DescriptionText, HighlightedBox, ButtonContainer } from './styled';
 import { fetchEvent } from 'src/api/events';
 import DeleteButton from 'src/components/inputs/DeleteButton';
 import PublishButton from 'src/components/inputs/PublishButton';
@@ -84,21 +84,23 @@ function EventPage({ eventId, navigate, ...rest }: EventPageProps) {
                     location={location}
                     owner={owner}
                   />
-                  <RsvpButton event={event} onSuccess={refreshEvent} />
-                  <DeleteButton event={event} onDelete={handleDelete} />
-                  {!isNotOwner && (
-                    <Button
-                      variant="highlight"
-                      onClick={() =>
-                        navigate!(`/update-event/${event.id}/${name}`)
-                      }
-                    >
-                      Edit
-                    </Button>
-                  )}
-                  {!isNotOwner && event.eventStatus === EventStatus.DRAFT && (
-                    <PublishButton event={event} onPublish={handlePublish} />
-                  )}
+                  <ButtonContainer>
+                    <RsvpButton event={event} onSuccess={refreshEvent} />
+                    <DeleteButton event={event} onDelete={handleDelete} />
+                    {!isNotOwner && (
+                      <Button
+                        variant="highlight"
+                        onClick={() =>
+                          navigate!(`/update-event/${event.id}/${name}`)
+                        }
+                      >
+                        Edit
+                      </Button>
+                    )}
+                    {!isNotOwner && event.eventStatus === EventStatus.DRAFT && (
+                      <PublishButton event={event} onPublish={handlePublish} />
+                    )}
+                  </ButtonContainer>
                 </HighlightedBox>
               </header>
               <SplitSection

--- a/src/pages/EventPage/EventPage.tsx
+++ b/src/pages/EventPage/EventPage.tsx
@@ -13,8 +13,10 @@ import TeamsLink from './components/TeamsLink';
 import { DescriptionText, HighlightedBox } from './styled';
 import { fetchEvent } from 'src/api/events';
 import DeleteButton from 'src/components/inputs/DeleteButton';
+import PublishButton from 'src/components/inputs/PublishButton';
 import Button from 'src/components/inputs/Button';
 import { AuthProviderInstance } from 'src/utils/auth';
+import { EventStatus } from 'src/utils/constants';
 
 type EventPageProps = {
   eventId: string;
@@ -27,6 +29,13 @@ function EventPage({ eventId, navigate, ...rest }: EventPageProps) {
   const handleDelete = useCallback(() => {
     navigate!('/');
   }, [navigate]);
+
+  const handlePublish = useCallback(
+    (path: string) => {
+      navigate!(path);
+    },
+    [navigate]
+  );
 
   return (
     <section id="event-page">
@@ -86,6 +95,9 @@ function EventPage({ eventId, navigate, ...rest }: EventPageProps) {
                     >
                       Edit
                     </Button>
+                  )}
+                  {!isNotOwner && event.eventStatus === EventStatus.DRAFT && (
+                    <PublishButton event={event} onPublish={handlePublish} />
                   )}
                 </HighlightedBox>
               </header>

--- a/src/pages/EventPage/EventPage.tsx
+++ b/src/pages/EventPage/EventPage.tsx
@@ -67,14 +67,14 @@ function EventPage({ eventId, navigate, ...rest }: EventPageProps) {
 
           const account = AuthProviderInstance.account;
 
-          const isNotOwner =
-            !owner || !account || account.localAccountId !== owner.id;
+          const isOwner =
+            owner && account && account.localAccountId === owner.id;
 
           return (
             <>
               <header>
                 <h1>{name}</h1>
-                {!isNotOwner && <StatusLabel eventStatus={eventStatus} />}
+                {isOwner && <StatusLabel eventStatus={eventStatus} />}
                 <HighlightedBox>
                   <MetaInfo
                     name={name}
@@ -87,7 +87,7 @@ function EventPage({ eventId, navigate, ...rest }: EventPageProps) {
                   <ButtonContainer>
                     <RsvpButton event={event} onSuccess={refreshEvent} />
                     <DeleteButton event={event} onDelete={handleDelete} />
-                    {!isNotOwner && (
+                    {isOwner && (
                       <Button
                         variant="highlight"
                         onClick={() =>
@@ -97,7 +97,7 @@ function EventPage({ eventId, navigate, ...rest }: EventPageProps) {
                         Edit
                       </Button>
                     )}
-                    {!isNotOwner && event.eventStatus === EventStatus.DRAFT && (
+                    {isOwner && event.eventStatus === EventStatus.DRAFT && (
                       <PublishButton event={event} onPublish={handlePublish} />
                     )}
                   </ButtonContainer>

--- a/src/pages/EventPage/components/StatusLabel/StatusLabel.tsx
+++ b/src/pages/EventPage/components/StatusLabel/StatusLabel.tsx
@@ -13,7 +13,7 @@ function StatusLabel({ eventStatus }: StatusLabelProps) {
   return (
     <Container>
       <Label color={color}>{label}</Label>
-      {isDraft && <HelpText>This event is only visible to you</HelpText>}
+      {isDraft && <HelpText>This event is only visible to you until you publish</HelpText>}
     </Container>
   );
 }

--- a/src/pages/EventPage/components/StatusLabel/StatusLabel.tsx
+++ b/src/pages/EventPage/components/StatusLabel/StatusLabel.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Container, Label, HelpText } from './styled';
-import { EVENT_STATUS_OPTIONS } from 'src/utils/constants'
+import { EventStatus } from 'src/utils/constants'
 
 type StatusLabelProps = {
   eventStatus: string;
 };
 
 function StatusLabel({ eventStatus }: StatusLabelProps) {
-  if (eventStatus === EVENT_STATUS_OPTIONS.Draft)
+  if (eventStatus === EventStatus.DRAFT)
     return (
       <Container>
         <Label color="grey">Draft</Label>

--- a/src/pages/EventPage/components/StatusLabel/StatusLabel.tsx
+++ b/src/pages/EventPage/components/StatusLabel/StatusLabel.tsx
@@ -1,26 +1,20 @@
 import React from 'react';
 import { Container, Label, HelpText } from './styled';
-import { EventStatus } from 'src/utils/constants'
+import { EventStatus } from 'src/utils/constants';
 
 type StatusLabelProps = {
   eventStatus: string;
 };
 
 function StatusLabel({ eventStatus }: StatusLabelProps) {
-  if (eventStatus === EventStatus.DRAFT)
-    return (
-      <Container>
-        <Label color="grey">Draft</Label>
-        <HelpText>This event is only visible to you</HelpText>
-      </Container>
-    );
-  else {
-    return (
-      <Container>
-        <Label color="green">Published</Label>
-      </Container>
-    );
-  }
+  const isDraft = eventStatus === EventStatus.DRAFT;
+  const label = isDraft ? 'Draft' : 'Published';
+  const color = isDraft ? 'grey' : 'green';
+  return (
+    <Container>
+      <Label color={color}>{label}</Label>
+      {isDraft && <HelpText>This event is only visible to you</HelpText>}
+    </Container>
+  );
 }
-
 export default StatusLabel;

--- a/src/pages/EventPage/components/StatusLabel/styled.ts
+++ b/src/pages/EventPage/components/StatusLabel/styled.ts
@@ -20,5 +20,5 @@ export const Label = styled.ul`
 
 export const HelpText = styled.ul`
   color: grey;
-  text-decoration: underline;
+  padding-left: 0;
 `;

--- a/src/pages/EventPage/styled.ts
+++ b/src/pages/EventPage/styled.ts
@@ -11,3 +11,8 @@ export const HighlightedBox = styled.div`
 export const DescriptionText = styled.div`
   white-space: pre-line;
 `;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  gap: 1rem;
+`;

--- a/src/pages/LandingPage/components/EventList/components/EventCard/components/CardStatusLabel/CardStatusLabel.tsx
+++ b/src/pages/LandingPage/components/EventList/components/EventCard/components/CardStatusLabel/CardStatusLabel.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Container, Label, HelpText } from './styled';
-import { EVENT_STATUS_OPTIONS } from 'src/utils/constants'
+import { EventStatus } from 'src/utils/constants'
 
 type StatusLabelProps = {
   eventStatus: string;
 };
 
 function CardStatusLabel({ eventStatus }: StatusLabelProps) {
-  if (eventStatus === EVENT_STATUS_OPTIONS.Draft)
+  if (eventStatus === EventStatus.DRAFT)
     return (
       <Container>
         <Label>

--- a/src/pages/LandingPage/components/EventList/components/EventCard/components/CardStatusLabel/CardStatusLabel.tsx
+++ b/src/pages/LandingPage/components/EventList/components/EventCard/components/CardStatusLabel/CardStatusLabel.tsx
@@ -1,23 +1,23 @@
 import React from 'react';
 import { Container, Label, HelpText } from './styled';
-import { EventStatus } from 'src/utils/constants'
+import { EventStatus } from 'src/utils/constants';
 
 type StatusLabelProps = {
   eventStatus: string;
 };
 
 function CardStatusLabel({ eventStatus }: StatusLabelProps) {
-  if (eventStatus === EventStatus.DRAFT)
-    return (
-      <Container>
-        <Label>
-          Draft<HelpText>This event is only visible to you</HelpText>
-        </Label>
-      </Container>
-    );
-  else {
+  if (eventStatus === EventStatus.PUBLISHED) {
     return null;
   }
+
+  return (
+    <Container>
+      <Label>
+        Draft<HelpText>This event is only visible to you</HelpText>
+      </Label>
+    </Container>
+  );
 }
 
 export default CardStatusLabel;

--- a/src/pages/LandingPage/components/EventList/components/EventCard/components/CardStatusLabel/styled.ts
+++ b/src/pages/LandingPage/components/EventList/components/EventCard/components/CardStatusLabel/styled.ts
@@ -13,7 +13,6 @@ export const Label = styled.ul`
   top: 0;
   left: 0;
   position: absolute;
-  //margin: 0;
   padding: 20px;
   background-color: rgba(0, 0, 0, 0.4);
   font-size: ${usingTypography((t) => t.scaleFont(5))}px;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,4 @@
-export enum EVENT_STATUS_OPTIONS {
-  Draft = 'Draft',
-  Published = 'Published',
+export enum EventStatus {
+  DRAFT = 'Draft',
+  PUBLISHED = 'Published',
 }


### PR DESCRIPTION
This PR aims to solve #72 

Made some changes based on feedback on a previous PR #67 which is already merged. Those changes were refactoring EventStatus enum to PascalCase for better naming convention. Additionally refactoring event components to be more idiomatic.

Made a small styling change to the status label in the event page for better UX.

Added a Publish button to the event page and removed the EventStatus selector from the create/update event page. The Publish button is only visible if the user is the owner and the event is a Draft. The publish button uses the same API endpoint as update event.

Added a reusable Modal component for confirmation from the user before publishing and deleting an event.