### PR TITLE
Fix text overflow on various components

### DIFF
--- a/src/components/Comment/Comment/styled.ts
+++ b/src/components/Comment/Comment/styled.ts
@@ -13,6 +13,10 @@ export const CommentContent = styled.div`
   padding: 20px;
   font-size: medium;
   background-color: #f0f0f0;
+
+  & > p {
+    overflow-wrap: anywhere;
+  }
 `;
 
 export const CommentAuthor = styled.p`

--- a/src/pages/EventPage/EventPage.tsx
+++ b/src/pages/EventPage/EventPage.tsx
@@ -11,7 +11,12 @@ import MetaInfo from './components/MetaInfo';
 import ParticipantList from './components/ParticipantList';
 import StatusLabel from './components/StatusLabel';
 import TeamsLink from './components/TeamsLink';
-import { DescriptionText, HighlightedBox, ButtonContainer } from './styled';
+import {
+  DescriptionText,
+  HighlightedBox,
+  ButtonContainer,
+  EventHeader,
+} from './styled';
 import { fetchEvent } from 'src/api/events';
 import DeleteButton from 'src/components/inputs/DeleteButton';
 import PublishButton from 'src/components/inputs/PublishButton';
@@ -75,7 +80,7 @@ function EventPage({ eventId, navigate, ...rest }: EventPageProps) {
           return (
             <>
               <header>
-                <h1>{name}</h1>
+                <EventHeader>{name}</EventHeader>
                 {isOwner && <StatusLabel eventStatus={eventStatus} />}
                 <HighlightedBox>
                   <MetaInfo

--- a/src/pages/EventPage/components/MetaInfo/styled.ts
+++ b/src/pages/EventPage/components/MetaInfo/styled.ts
@@ -15,6 +15,7 @@ export const MetaInfoLabel = styled.dt`
 `;
 
 export const MetaInfoValue = styled.dl`
+  overflow-wrap: anywhere;
   margin: 0;
   padding: 0;
 `;

--- a/src/pages/EventPage/styled.ts
+++ b/src/pages/EventPage/styled.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { usingTypography, usingColors } from 'src/hooks/theme';
 
 export const EventHeader = styled.h1`
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 `;
 
 export const HighlightedBox = styled.div`

--- a/src/pages/EventPage/styled.ts
+++ b/src/pages/EventPage/styled.ts
@@ -2,6 +2,10 @@ import styled from 'styled-components';
 
 import { usingTypography, usingColors } from 'src/hooks/theme';
 
+export const EventHeader = styled.h1`
+  overflow-wrap: break-word;
+`;
+
 export const HighlightedBox = styled.div`
   padding: ${usingTypography((t) => t.scaleSpacing(6))}px;
   color: ${usingColors((c) => c.ON.SECONDARY)};
@@ -10,6 +14,7 @@ export const HighlightedBox = styled.div`
 
 export const DescriptionText = styled.div`
   white-space: pre-line;
+  overflow-wrap: anywhere;
 `;
 
 export const ButtonContainer = styled.div`

--- a/src/pages/LandingPage/components/EventList/components/EventCard/styled.ts
+++ b/src/pages/LandingPage/components/EventList/components/EventCard/styled.ts
@@ -25,6 +25,7 @@ export const Image = styled.img`
 export const Body = styled.div`
   display: flex;
   flex-direction: column;
+  overflow-wrap: anywhere;
   padding: 0 ${usingTypography((t) => t.scaleSpacing(5))}px;
   padding-bottom: ${usingTypography((t) => t.scaleSpacing(2))}px;
 


### PR DESCRIPTION
Closes #82

Added css property `overflow-wrap: anywhere` to components with overflow issues for long single worded text strings

Before:
![Skjermbilde 2021-09-27 kl  10 23 11](https://user-images.githubusercontent.com/7560693/134877878-86d701e2-d27e-43ae-a287-ff61bacfc178.png)

After:
![Skjermbilde 2021-09-27 kl  10 58 24](https://user-images.githubusercontent.com/7560693/134877955-a70ce222-6d98-4de3-a80c-4bb257e0cc7f.png)
