### PR TITLE
fix: remove 0 when resouceLinks is empty

### DIFF
--- a/src/pages/EventPage/EventPage.tsx
+++ b/src/pages/EventPage/EventPage.tsx
@@ -138,7 +138,7 @@ function EventPage({ eventId, navigate, ...rest }: EventPageProps) {
                 }
                 right={
                   <>
-                    {resourceLinks?.length && (
+                    {resourceLinks && resourceLinks.length > 0 && (
                       <ResourceLinkList resourceLinks={resourceLinks} />
                     )}
                     {participants && (


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/10965541/137863653-4ec4fa31-77a2-4f1e-8d78-dc380269bc16.png)

After
![image](https://user-images.githubusercontent.com/10965541/137863541-b63ddaca-4f82-44cb-8017-092115acfafa.png)
